### PR TITLE
fix packagist project's name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and used for simplify testing of Symfony DI.
 Install extension using [composer](https://getcomposer.org):
 
 ```
-composer require --dev jdecool/atoum-symfony-di
+composer require --dev jdecool/atoum-symfony-di-extension
 ```
 
 Enable the extension using atoum configuration file:


### PR DESCRIPTION
cf https://packagist.org/packages/jdecool/atoum-symfony-di-extension