### PR TITLE
removes an error when containerBuilder is not an object

### DIFF
--- a/classes/asserters/containerBuilder.php
+++ b/classes/asserters/containerBuilder.php
@@ -113,7 +113,7 @@ class containerBuilder extends asserters\variable
 			}
 			else
 			{
-				$this->fail($this->_('%s is not an instance of Symfony\Component\DependencyInjection\ContainerBuilder', get_class($this->value)));
+				$this->fail($this->_('%s is not an instance of Symfony\Component\DependencyInjection\ContainerBuilder', is_object($this->value) ? get_class($this->value) : gettype($this->value)));
 			}
 		}
 


### PR DESCRIPTION
When the parameter passed to the containerBuilder were an not an object, an error were displayed.

For exemple if we did something like this:
```
->containerBuilder('a')
```

This error were displayed:
![avant](https://cloud.githubusercontent.com/assets/320372/21076906/cd9f9518-bf38-11e6-925f-57bce4d29a1e.png)

Now this error is displayed:
![apres](https://cloud.githubusercontent.com/assets/320372/21076907/d7438200-bf38-11e6-83eb-1092b1b59867.png)


